### PR TITLE
Fix TC build on travis

### DIFF
--- a/src/LuaEngine/LuaEngine.cpp
+++ b/src/LuaEngine/LuaEngine.cpp
@@ -79,9 +79,10 @@ bool StartEluna()
     RegisterFunctions(sEluna->L);
 
     // Randomize math.random()
+    // The macro fails on TC for unknown reason
+    // luaL_dostring(sEluna->L, "math.randomseed( tonumber(tostring(os.time()):reverse():sub(1,6)) )");
     if (!luaL_loadstring(sEluna->L, "math.randomseed( tonumber(tostring(os.time()):reverse():sub(1,6)) )"))
         lua_pcall(sEluna->L, 0, LUA_MULTRET, 0);
-    // luaL_dostring(sEluna->L, "math.randomseed( tonumber(tostring(os.time()):reverse():sub(1,6)) )");
 
     uint32 count = 0;
     char filename[200];


### PR DESCRIPTION
For some reason calling luaL_dostring results to

```
LuaEngine.cpp:82:99: error: macro "lua_pcall" passed 5 arguments, but takes just 4
```

Even though the function is used like

```
lua_pcall(sEluna->L, 0, LUA_MULTRET, 0);
```
