### PR TITLE
Fix player timed events not carrying over between maps

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1850,9 +1850,8 @@ void WorldObject::SetMap(Map* map)
     m_InstanceId = map->GetInstanceId();
 
 #ifdef ELUNA
-    delete elunaEvents;
-    // On multithread replace this with a pointer to map's Eluna pointer stored in a map
-    elunaEvents = new ElunaEventProcessor(&Eluna::GEluna, this);
+    if (!elunaEvents)
+        elunaEvents = new ElunaEventProcessor(&Eluna::GEluna, this);
 #endif
 
     if (IsWorldObject())
@@ -1865,11 +1864,6 @@ void WorldObject::ResetMap()
     ASSERT(!IsInWorld());
     if (IsWorldObject())
         m_currMap->RemoveWorldObject(this);
-
-#ifdef ELUNA
-    delete elunaEvents;
-    elunaEvents = NULL;
-#endif
 
     m_currMap = nullptr;
     //maybe not for corpse


### PR DESCRIPTION
Timed events tied to players are removed when a player teleports from one map to another.

See https://discord.com/channels/817077195817353226/1074254244561031248/1074254244561031248